### PR TITLE
Proposed Fix for AppIconView to work on Mac Catalyst

### DIFF
--- a/Sources/iOS-Common-Libraries/Views/AppIconView.swift
+++ b/Sources/iOS-Common-Libraries/Views/AppIconView.swift
@@ -25,7 +25,7 @@ public struct AppIconView: View {
             .resizable()
             .aspectRatio(contentMode: .fit)
             .cornerRadius(AppIconView.appCornerRadious)
-        #elseif os(iOS)
+        #elseif os(iOS) || targetEnvironment(macCatalyst)
         Bundle.main.iconFileName
             .flatMap { UIImage(named: $0) }
             .map {
@@ -40,16 +40,19 @@ public struct AppIconView: View {
 
 // MARK: Icon
 
-#if os(iOS)
+#if os(iOS) || targetEnvironment(macCatalyst)
 internal extension Bundle {
     
     var iconFileName: String? {
-        guard let icons = infoDictionary?["CFBundleIcons"] as? [String: Any],
-              let primaryIcon = icons["CFBundlePrimaryIcon"] as? [String: Any],
-              let iconFiles = primaryIcon["CFBundleIconFiles"] as? [String],
-              let iconFileName = iconFiles.last
-        else { return nil }
-        return iconFileName
+        if let icons = infoDictionary?["CFBundleIcons"] as? [String: Any],
+           let primaryIcon = icons["CFBundlePrimaryIcon"] as? [String: Any],
+           let iconFiles = primaryIcon["CFBundleIconFiles"] as? [String],
+           let iconFileName = iconFiles.last {
+            return iconFileName
+        } else if let bundleAppIcon = infoDictionary?["CFBundleIconFile"] as? String {
+            return bundleAppIcon
+        }
+        return nil
     }
 }
 #endif


### PR DESCRIPTION
Mac Catalyst is not 'OSX'. Because we don't get the same APIs, but a mixture of what was allowed or implemented as UIKit on macOS. Weird stuff I know.