### PR TITLE
Fix: BitField's all() static function was not made Public

### DIFF
--- a/Sources/iOS-Common-Libraries/Utilities/BitField.swift
+++ b/Sources/iOS-Common-Libraries/Utilities/BitField.swift
@@ -17,7 +17,7 @@ public struct BitField<T: Option>: Hashable, Codable, ExpressibleByArrayLiteral 
     
     // MARK: all()
     
-    static func all() -> Self {
+    public static func all() -> Self {
         return BitField<T>(T.allCases.map { $0 })
     }
     


### PR DESCRIPTION
Sacrilege! But that's the good thing about making an API that you use Public, and then using it. You can test that it works or, compiles, as it should!