### PR TITLE
Made Cache Utility Public

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,5 @@ This is a Swift Package containing Swift code and Utilities/Assets, such as Colo
 
 ### Utilities
 
+- `Cache`: Need to use `NSCache` with a pure-Swift `struct`? This is what this is for. Also, it's just John Sundell's work in a library that we use.
 - `BitField`: Alternative to an `enum` `Set` that allows us to store everything in a single CPU Register, both in memory and as a `Codable`. Heavily used by [nRF Connect for Mobile](https://apps.apple.com/es/app/nrf-connect-for-mobile/id1054362403).

--- a/Sources/iOS-Common-Libraries/Utilities/Cache.swift
+++ b/Sources/iOS-Common-Libraries/Utilities/Cache.swift
@@ -10,13 +10,13 @@ import Foundation
 /**
  - Source: [Swift by Sundell](https://www.swiftbysundell.com/articles/caching-in-swift/)
  */
-final class Cache<Key: Hashable, Value> {
+public final class Cache<Key: Hashable, Value> {
     
     private let wrapped = NSCache<WrappedKey, Entry>()
     
     // MARK: - Subscript API
     
-    subscript(key: Key) -> Value? {
+    public subscript(key: Key) -> Value? {
         get {
             let wrappedKey = WrappedKey(key)
             return wrapped.object(forKey: wrappedKey)?.value
@@ -31,6 +31,14 @@ final class Cache<Key: Hashable, Value> {
             }
             wrapped.setObject(Entry(value: value), forKey: wrappedKey)
         }
+    }
+    
+    public func removeValue(forKey key: Key) {
+        wrapped.removeObject(forKey: WrappedKey(key))
+    }
+
+    public func clear() {
+        wrapped.removeAllObjects()
     }
 }
 


### PR DESCRIPTION
If it's not public, we can't use it! Also, it was missing two functions that nRF Connect uses.