### PR TITLE
Missing Public Initializers

### DIFF
--- a/Sources/iOS-Common-Libraries/Utilities/SwiftUI/ViewModifiers.swift
+++ b/Sources/iOS-Common-Libraries/Utilities/SwiftUI/ViewModifiers.swift
@@ -15,7 +15,7 @@ public struct RoundedTextFieldShape: ViewModifier {
     private let backgroundColor: Color
     private let hasTextFieldBelow: Bool
     
-    init(_ backgroundColor: Color, hasTextFieldBelow: Bool = false) {
+    public init(_ backgroundColor: Color, hasTextFieldBelow: Bool = false) {
         self.backgroundColor = backgroundColor
         self.hasTextFieldBelow = hasTextFieldBelow
     }

--- a/Sources/iOS-Common-Libraries/Views/PasswordField.swift
+++ b/Sources/iOS-Common-Libraries/Views/PasswordField.swift
@@ -24,7 +24,7 @@ public struct PasswordField: View {
     
     // MARK: Init
     
-    init(_ binding: Binding<String>, enabled: Bool) {
+    public init(_ binding: Binding<String>, enabled: Bool) {
         self.password = binding
         self.enabled = enabled
     }


### PR DESCRIPTION
I understand why init is not made public by default if the type is public. But doesn't it lend to these kinds of situations all the time...