### PR TITLE
Added Pipeline from Wi-Fi Provisioner

### DIFF
--- a/Sources/iOS-Common-Libraries/Views/Pipeline/PipelineManager.swift
+++ b/Sources/iOS-Common-Libraries/Views/Pipeline/PipelineManager.swift
@@ -1,0 +1,115 @@
+//
+//  PipelineManager.swift
+//  nRF-Wi-Fi-Provisioner (iOS)
+//
+//  Created by Dinesh Harjani on 18/4/24.
+//
+
+import Foundation
+
+// MARK: - PipelineManager
+
+public class PipelineManager<Stage: PipelineStage>: ObservableObject {
+    
+    // MARK: Properties
+    
+    @Published public var stages: [Stage]
+    @Published public var progress: Double
+    @Published public var started: Bool
+    @Published public var success: Bool {
+        didSet {
+            defer {
+                delegate?.onProgressUpdate()
+            }
+            
+            guard success else { return }
+            for i in stages.indices {
+                stages[i].update(isCompleted: true)
+            }
+            progress = 100.0
+        }
+    }
+    @Published public var error: Error?
+    
+    weak public var delegate: PipelineManagerDelegate?
+    
+    public var currentStage: Stage! {
+        stages.first { $0.inProgress }
+    }
+    
+    public var inProgress: Bool {
+        currentStage != nil
+    }
+    
+    public var finishedWithError: Bool {
+        !success && error != nil
+    }
+    
+    public var isIndeterminate: Bool {
+        currentStage?.isIndeterminate ?? true
+    }
+    
+    // MARK: Init
+    
+    public init(initialStages stages: [Stage]) {
+        self.stages = stages
+        self.progress = 0.0
+        self.started = false
+        self.success = false
+        for i in self.stages.indices {
+            self.stages[i].update(inProgress: false, isCompleted: false)
+        }
+    }
+}
+
+// MARK: - Delegate
+
+public protocol PipelineManagerDelegate: AnyObject {
+    
+    func onProgressUpdate()
+}
+
+// MARK: - Public API
+
+public extension PipelineManager {
+    
+    func stagesBefore(_ stage: Stage) -> Array<Stage>.SubSequence {
+        return stages.prefix(while: { $0 != stage })
+    }
+    
+    func stagesFrom(_ stage: Stage) -> Array<Stage>.SubSequence {
+        guard let limitIndex = stages.firstIndex(where: { $0.id == stage.id }) else {
+            return []
+        }
+        return stages.suffix(from: limitIndex)
+    }
+    
+    func isCompleted(_ stage: Stage) -> Bool {
+        guard let index = stages.firstIndex(where: { $0.id == stage.id }) else { return false }
+        return stages[index].completed
+    }
+    
+    func inProgress(_ stage: Stage, speed: Double? = nil) {
+        guard let index = stages.firstIndex(where: { $0.id == stage.id }) else { return }
+        started = true
+        stages[index].update(inProgress: true)
+        
+        for previousIndex in stages.indices where previousIndex < index {
+            stages[previousIndex].update(isCompleted: true)
+        }
+        delegate?.onProgressUpdate()
+    }
+    
+    func completed(_ stage: Stage) {
+        guard let index = stages.firstIndex(where: { $0.id == stage.id }) else { return }
+        stages[index].update(isCompleted: true)
+        delegate?.onProgressUpdate()
+    }
+    
+    func onError(_ error: Error) {
+        guard let currentStage = stages.firstIndex(where: { $0.inProgress }) else { return }
+        stages[currentStage].declareError()
+        self.error = error
+        delegate?.onProgressUpdate()
+    }
+}

--- a/Sources/iOS-Common-Libraries/Views/Pipeline/PipelineStage.swift
+++ b/Sources/iOS-Common-Libraries/Views/Pipeline/PipelineStage.swift
@@ -1,0 +1,63 @@
+//
+//  PipelineStage.swift
+//  nRF-Wi-Fi-Provisioner (iOS)
+//  iOS-Common-Libraries
+//
+//  Created by Dinesh Harjani on 17/4/24.
+//
+
+import Foundation
+import SwiftUI
+
+// MARK: - PipelineStage
+
+public protocol PipelineStage: Identifiable, Hashable, CaseIterable {
+    
+    var symbolName: String { get }
+    var todoStatus: String { get }
+    var inProgressStatus: String { get }
+    var completedStatus: String { get }
+    var progress: Float { get }
+    var totalProgress: Float { get }
+    var isIndeterminate: Bool { get }
+    var completed: Bool { get set }
+    var inProgress: Bool { get set }
+    var encounteredAnError: Bool { get set }
+}
+
+public extension PipelineStage {
+    
+    var id: String { todoStatus }
+    
+    var status: String {
+        guard !completed else { return completedStatus }
+        return inProgress || encounteredAnError ? inProgressStatus : todoStatus
+    }
+    
+    var color: Color {
+        if completed {
+            return .succcessfulActionButtonColor
+        } else if encounteredAnError {
+            return .nordicRed
+        } else if inProgress {
+            return .nordicSun
+        }
+        return .disabledTextColor
+    }
+    
+    var isIndeterminate: Bool {
+        totalProgress <= .leastNonzeroMagnitude
+    }
+    
+    mutating func update(inProgress: Bool = false, isCompleted: Bool = false) {
+        self.encounteredAnError = false
+        self.inProgress = inProgress
+        self.completed = isCompleted
+    }
+    
+    mutating func declareError() {
+        guard inProgress else { return }
+        inProgress = false
+        encounteredAnError = true
+    }
+}

--- a/Sources/iOS-Common-Libraries/Views/Pipeline/PipelineView.swift
+++ b/Sources/iOS-Common-Libraries/Views/Pipeline/PipelineView.swift
@@ -1,0 +1,60 @@
+//
+//  PipelineView.swift
+//  iOS-Common-Libraries
+//
+//  Created by Dinesh Harjani on 22/5/24.
+//
+
+import SwiftUI
+
+// MARK: - PipelineView
+
+public struct PipelineView<Stage: PipelineStage>: View {
+    
+    private let stage: Stage
+    private let logLine: String
+    
+    // MARK: Init
+    
+    public init(stage: Stage, logLine: String) {
+        self.stage = stage
+        self.logLine = logLine
+    }
+    
+    // MARK: View
+    
+    public var body: some View {
+        HStack {
+            Image(systemName: stage.symbolName)
+                .foregroundColor(stage.color)
+                .frame(width: 20, height: 20)
+            
+            VStack(alignment: .leading, spacing: 2) {
+                Text(stage.status)
+                    .foregroundColor(stage.color)
+
+                if stage.inProgress || stage.encounteredAnError {
+                    Text(logLine)
+                        .font(.caption)
+#if os(macOS)
+                        .padding(.top, 1)
+#endif
+                }
+                
+                if stage.inProgress {
+                    if stage.isIndeterminate {
+                        IndeterminateProgressView()
+                            .padding(.top, 2)
+                            .padding(.trailing)
+                    } else {
+                        ProgressView(value: stage.progress, total: stage.totalProgress)
+                            .progressViewStyle(.linear)
+                            .padding(.top, 2)
+                            .padding(.trailing)
+                    }
+                }
+            }
+            .padding(.leading, 6)
+        }
+    }
+}


### PR DESCRIPTION
The Pipeline from Wi-Fi Provisioner was originally stolen from Edge Impulse, but updated and written to make it reusable. So now we're adding it into the library, and we're going to find out how reusable it is when Edge Impulse adapts it.