### PR TITLE
PipelineView now supports an extra 1-line Accessory Line

### DIFF
--- a/Sources/iOS-Common-Libraries/Views/Pipeline/PipelineView.swift
+++ b/Sources/iOS-Common-Libraries/Views/Pipeline/PipelineView.swift
@@ -13,12 +13,14 @@ public struct PipelineView<Stage: PipelineStage>: View {
     
     private let stage: Stage
     private let logLine: String
+    private let accessoryLine: String?
     
     // MARK: Init
     
-    public init(stage: Stage, logLine: String) {
+    public init(stage: Stage, logLine: String, accessoryLine: String? = nil) {
         self.stage = stage
         self.logLine = logLine
+        self.accessoryLine = accessoryLine
     }
     
     // MARK: View
@@ -39,6 +41,13 @@ public struct PipelineView<Stage: PipelineStage>: View {
 #if os(macOS)
                         .padding(.top, 1)
 #endif
+                }
+                
+                if let accessoryLine {
+                    Text(accessoryLine)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
                 }
                 
                 if stage.inProgress {


### PR DESCRIPTION
This is a provision for Edge Impulse app, which does need this.