### PR TITLE
Fix for PipelineView accessory line

### DIFF
--- a/Sources/iOS-Common-Libraries/Views/Pipeline/PipelineView.swift
+++ b/Sources/iOS-Common-Libraries/Views/Pipeline/PipelineView.swift
@@ -43,14 +43,14 @@ public struct PipelineView<Stage: PipelineStage>: View {
 #endif
                 }
                 
-                if let accessoryLine {
-                    Text(accessoryLine)
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                        .lineLimit(1)
-                }
-                
                 if stage.inProgress {
+                    if let accessoryLine {
+                        Text(accessoryLine)
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                    }
+                    
                     if stage.isIndeterminate {
                         IndeterminateProgressView()
                             .padding(.top, 2)


### PR DESCRIPTION
We only want to show it when we're in progress, and without errors.