### PR TITLE
Limited Pipeline log lines to 1

### DIFF
--- a/Sources/iOS-Common-Libraries/Views/Pipeline/PipelineView.swift
+++ b/Sources/iOS-Common-Libraries/Views/Pipeline/PipelineView.swift
@@ -38,6 +38,7 @@ public struct PipelineView<Stage: PipelineStage>: View {
                 if stage.inProgress || stage.encounteredAnError {
                     Text(logLine)
                         .font(.caption)
+                        .lineLimit(1)
 #if os(macOS)
                         .padding(.top, 1)
 #endif


### PR DESCRIPTION
Otherwise long longs would destroy the UI.