### PR TITLE
Change: InlinePicker no longer sets a default content style

### DIFF
--- a/Sources/iOS-Common-Libraries/Views/InlinePicker.swift
+++ b/Sources/iOS-Common-Libraries/Views/InlinePicker.swift
@@ -56,7 +56,6 @@ public struct InlinePicker<T: Hashable & Equatable>: View {
                 Text(title)
             }
         }
-        .labeledContentStyle(.accentedContent(lineLimit: 0))
     }
 }
 


### PR DESCRIPTION
Until now, the content style was set to Accented Content. Now, it's not set.