### PR TITLE
Fix for bad StackNavigationViewStyle init

### DIFF
--- a/Sources/iOS-Common-Libraries/Extensions/View.swift
+++ b/Sources/iOS-Common-Libraries/Extensions/View.swift
@@ -135,7 +135,7 @@ public extension NavigationView {
     func setSingleColumnNavigationViewStyle() -> some View {
         self
         #if os(iOS)
-            .navigationViewStyle(StackNavigationViewStyle())
+            .navigationViewStyle(.stack)
         #endif
     }
     


### PR DESCRIPTION
Documentation states to not use the initialiser directly, and to instead use the .stack static variable. I did not find this, instead it came through this StackOverflow link: https://stackoverflow.com/questions/65316497/swiftui-navigationview-navigationbartitle-layoutconstraints-issue