### PR TITLE
Added UIView Helper Methods to detect whether a view is currently part of the view hierarchy

### DIFF
--- a/Sources/iOS-Common-Libraries/Extensions/UIView.swift
+++ b/Sources/iOS-Common-Libraries/Extensions/UIView.swift
@@ -1,0 +1,39 @@
+//
+//  UIView.swift
+//  iOS-Common-Libraries
+//
+//  Created by Dinesh Harjani on 29/7/24.
+//  Copyright © 2024 Nordic Semiconductor. All rights reserved.
+//
+
+import UIKit
+
+public extension UIView {
+    
+    /**
+     Helper function to detect whether a `UIView` is part of a view hierarchy to prevent unneeded updates. In [nRF Connect](https://github.com/NordicSemiconductor/IOS-nRF-Connect), this is critical to ensure `UITableView`(s) do not fire data source changes when they're being swapped out, for example.
+     
+     - returns: True if a `UIWindow` is present upstream this view's responder chain.
+     */
+    func isAttachedToViewHierarchy() -> Bool {
+        return firstParentWindow() != nil
+    }
+    
+    /**
+     Travels through the `UIView`'s responder chain to find its first parent `UIWindow`.
+     
+     - returns: First `UIWindow` present up the responder chain.
+     - seealso: [Apple Developer Event Handling using the responder chain](https://developer.apple.com/documentation/uikit/touches_presses_and_gestures/using_responders_and_the_responder_chain_to_handle_events) documentation.
+     */
+    func firstParentWindow() -> UIWindow? {
+        var parentResponder: UIResponder? = self.next
+        while parentResponder != nil {
+            guard let parentViewController = parentResponder as? UIWindow else {
+                parentResponder = parentResponder?.next
+                continue
+            }
+            return parentViewController
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
I tried to add some documentation as well. I wrote this for nRF Connect, but then thought it was "open" enough to be added to the common library. I don't think it'll be used much since modern apps now just rely on SwiftUI to handle the magic for events such as rotation, resizing and so on. This is where this helper is needed for nRF Connect.