### PR TITLE
NordicLog Update to better handle UIView(s)

### DIFF
--- a/Sources/iOS-Common-Libraries/Extensions/NordicLog.swift
+++ b/Sources/iOS-Common-Libraries/Extensions/NordicLog.swift
@@ -30,8 +30,10 @@ public struct NordicLog {
     // MARK: - Init
     
     public init(_ object: AnyObject, subsystem: String, delegate: Delegate? = nil) {
-        // Remove bundleName if possible.
-        let category = String(describing: object).components(separatedBy: ".").last
+        // Remove bundleName and clean UIView descriptions.
+        let category = String(describing: object)
+                .components(separatedBy: ".").last?
+                .components(separatedBy: ";").first
             ?? String(describing: object)
         self.init(category: category, subsystem: subsystem, delegate: delegate)
     }


### PR DESCRIPTION
What we need to know when logging from objects is their class name and their address, to be able to see if a different instance of said object is sending the logs. So we need to clear this out better.