### PR TITLE
Change: setupNavBarBackground() is no longer tied to NavigationView

### DIFF
--- a/Sources/iOS-Common-Libraries/Extensions/View.swift
+++ b/Sources/iOS-Common-Libraries/Extensions/View.swift
@@ -56,6 +56,22 @@ public extension View {
         #endif
     }
     
+    func setupNavBarBackground(with color: Color) -> some View {
+         #if os(iOS)
+         let appearance = UINavigationBarAppearance()
+         let attributes: [NSAttributedString.Key: Any] = [
+            .foregroundColor: UIColor.white
+         ]
+         appearance.titleTextAttributes = attributes
+         appearance.largeTitleTextAttributes = attributes
+         appearance.backgroundColor = color.uiColor // Dynamic Color.
+         UINavigationBar.appearance().compactAppearance = appearance
+         UINavigationBar.appearance().standardAppearance = appearance
+         UINavigationBar.appearance().scrollEdgeAppearance = appearance
+         #endif
+         return self
+    }
+    
     // MARK: - NavigationView
     
     @ViewBuilder
@@ -64,8 +80,8 @@ public extension View {
         NavigationView {
             self
         }
-        .setupNavBarBackground(with: color)
         .setSingleColumnNavigationViewStyle()
+        .setupNavBarBackground(with: color)
         .accentColor(.white)
         #else
         self
@@ -137,21 +153,5 @@ public extension NavigationView {
         #if os(iOS)
             .navigationViewStyle(.stack)
         #endif
-    }
-    
-    func setupNavBarBackground(with color: Color) -> NavigationView {
-         #if os(iOS)
-         let appearance = UINavigationBarAppearance()
-         let attributes: [NSAttributedString.Key: Any] = [
-            .foregroundColor: UIColor.white
-         ]
-         appearance.titleTextAttributes = attributes
-         appearance.largeTitleTextAttributes = attributes
-         appearance.backgroundColor = color.uiColor // Dynamic Color.
-         UINavigationBar.appearance().compactAppearance = appearance
-         UINavigationBar.appearance().standardAppearance = appearance
-         UINavigationBar.appearance().scrollEdgeAppearance = appearance
-         #endif
-         return self
     }
 }


### PR DESCRIPTION
This is because, for example, with NavigationSplitView, we get a NavigationView implicitly I think, so we need to be able to use this helper outside a NavigationView.