### PR TITLE
Internal Usage of the newly added CGSize(asSquare:) initialiser

### DIFF
--- a/Sources/iOS-Common-Libraries/Views/FPSCounter.swift
+++ b/Sources/iOS-Common-Libraries/Views/FPSCounter.swift
@@ -14,7 +14,7 @@ import SwiftUI
 @available(iOS 16.0, macCatalyst 16.0, macOS 13.0, *)
 public final class FPSCounter {
     
-    private static let DotSize = CGSize(width: 8.0, height: 8.0)
+    private static let DotSize = CGSize(asSquare: 8.0)
     
     // MARK: Private Properties
     

--- a/Sources/iOS-Common-Libraries/Views/NoContentView.swift
+++ b/Sources/iOS-Common-Libraries/Views/NoContentView.swift
@@ -66,7 +66,7 @@ public struct NoContentView: View {
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .frame(size: CGSize(width: 60.0, height: 60.0))
+                    .frame(size: CGSize(asSquare: 60.0))
                     .foregroundStyle(style.tintColor)
                     .rotationEffect(Angle.degrees(rotationAngle))
                     .onAppear {


### PR DESCRIPTION
Makes sense to use our own extensions.