### PR TITLE
Reverted to previous CancellableTextField Background Color for iOS / Catalyst

### DIFF
--- a/Sources/iOS-Common-Libraries/Views/CancellableTextField.swift
+++ b/Sources/iOS-Common-Libraries/Views/CancellableTextField.swift
@@ -95,7 +95,11 @@ public struct CancellableTextField: View {
                     .padding(4)
                 }
             }
-            .background(Color.secondarylabel)
+            #if os(iOS) || targetEnvironment(macCatalyst)
+            .background(Color(.systemGray6))
+            #else
+            .background(Color.secondarySystemBackground)
+            #endif
             .cornerRadius(8)
             
             if isEditing {


### PR DESCRIPTION
We don't have a good color for the Mac. I mean, when we do need one for a Mac, proper Mac not Catalyst app, I hope we can come up with one.