### PR TITLE
Fix: NordicDataParser's isValid() API should be public

### DIFF
--- a/Sources/iOS-Common-Libraries/Parsers/NordicDataParser.swift
+++ b/Sources/iOS-Common-Libraries/Parsers/NordicDataParser.swift
@@ -27,7 +27,7 @@ public protocol NordicDataParser: Hashable, Equatable, CustomStringConvertible {
 
 // MARK: isValid()
 
-extension NordicDataParser {
+public extension NordicDataParser {
     
     func isValid(_ data: Data) -> Bool {
         switch dataSizeRequirement {


### PR DESCRIPTION
At least, that was the original intention.