### PR TITLE
Renamed AcceptedByteCount "greaterThan" to "moreThan"

### DIFF
--- a/Sources/iOS-Common-Libraries/Parsers/NordicDataParser.swift
+++ b/Sources/iOS-Common-Libraries/Parsers/NordicDataParser.swift
@@ -39,7 +39,7 @@ public extension NordicDataParser {
             return data.count == byteCount
         case .atLeast(let minimumByteCount):
             return data.count >= minimumByteCount
-        case .greaterThan(let byteCount):
+        case .moreThan(let byteCount):
             return data.count > byteCount
         }
     }
@@ -52,5 +52,5 @@ public enum NordicDataParserValidSize {
     case anyOf(_ acceptedByteCounts: [Int])
     case exactly(_ bytes: Int)
     case atLeast(_ bytes: Int)
-    case greaterThan(_ bytes: Int)
+    case moreThan(_ bytes: Int)
 }


### PR DESCRIPTION
A few characters less, and also easier on the mind.