### PR TITLE
Defense against GlucoseMeasurement Data Parsing Crash

### DIFF
--- a/Sources/iOS-Common-Libraries/Parsers/GlucoseMeasurement.swift
+++ b/Sources/iOS-Common-Libraries/Parsers/GlucoseMeasurement.swift
@@ -50,7 +50,7 @@ public struct GlucoseMeasurement {
             return Measurement<UnitDuration>(value: Double(timeOffset), unit: .minutes)
         }() : nil
         
-        guard flags.contains(.typeAndLocation) else { return nil }
+        guard flags.contains(.typeAndLocation) && offset + SFloatReserved.byteSize <= data.count else { return nil }
         let value = Float(asSFloat: data.subdata(in: offset..<offset+SFloatReserved.byteSize))
         offset += SFloatReserved.byteSize
         if flags.contains(.concentrationUnit) {


### PR DESCRIPTION
nRF Connect attempts to parse anything as Data. So, bad "Data" might be given to parse, so we must be defensive and not think that just because we're getting called, we're going to get valid Data to parse. The goal is to not crash, and if gibberish is what we get, gibberish is what should go out. But no crashing.

This won't be the last of it, of course.